### PR TITLE
graph.add method renamed to graph.create

### DIFF
--- a/zabbix/zabbix_api.py
+++ b/zabbix/zabbix_api.py
@@ -2121,9 +2121,9 @@ class ZabbixAPIGraph(ZabbixAPISubClass):
 """
         return opts
 
-    @dojson('graph.add')
+    @dojson('graph.create')
     @checkauth
-    def add(self,**opts):
+    def create(self,**opts):
         """  * Add graph
  *
  * <code>


### PR DESCRIPTION
In current api version no graph.add method defined, graph.create must be used for operation
http://www.zabbix.com/documentation/1.8/api/graph/create
