### PR TITLE
Updated zabbix_api.py to use user.create

### DIFF
--- a/zabbix/zabbix_api.py
+++ b/zabbix/zabbix_api.py
@@ -388,9 +388,9 @@ class ZabbixAPIUser(ZabbixAPISubClass):
  * @return string|boolean """
         return opts
 
-    @dojson('user.add')
+    @dojson('user.create')
     @checkauth
-    def add(self,**opts):
+    def create(self,**opts):
         """  * Add Users
  *
  * {@source}


### PR DESCRIPTION
Hello, Thanks for creating zabbix_api.py. I was trying to use it to add users to zabbix and realized that the api call you're trying to use in zabbix_api.py file is user.add. The call is user.create. I guess user.add was what earlier versions of the api used I guess..

I've updated the call to be user.create and would like you to merge the fix.

Thanks!
