### PR TITLE
Change used Content-Type from json-rpc to json

### DIFF
--- a/zabbix/zabbix_api.py
+++ b/zabbix/zabbix_api.py
@@ -256,7 +256,7 @@ class ZabbixAPI(object):
             return False
 
     def do_request(self, json_obj):
-        headers = {'Content-Type': 'application/json-rpc',
+        headers = {'Content-Type': 'application/json',
                    'User-Agent': 'python/zabbix_api'}
 
         if self.httpuser:


### PR DESCRIPTION
application/json-rpc is defined only in draft spec for JSON-RPC 1.2 http://www.jsonrpc.org/historical/json-rpc-over-http.html which is deprecated in favor of JSON-RPC 2.0 and application/json

Also application/json-rpc isn't parsed by wireshark.
