### PR TITLE
Raise exception on API request error

### DIFF
--- a/zabbix/zabbix_api.py
+++ b/zabbix/zabbix_api.py
@@ -288,8 +288,7 @@ class ZabbixAPI(object):
         try:
             response = opener.open(request, timeout=self.timeout)
         except Exception as e:
-            self.debug(logging.ERROR, "Site needs HTTP authentication. Error: "+str(e))
-            sys.exit(-1)
+            raise ZabbixAPIException("Site needs HTTP authentication. Error: "+str(e))
         self.debug(logging.INFO, "Response Code: " + str(response.code))
 
         # NOTE: Getting a 412 response code means the headers are not in the


### PR DESCRIPTION
Hi I here show the rationale of my commit.

I use a wrapper to catch any uncaught exception in my Python cron jobs. I find one of them were not running correctly in the last day. When I run it manually it, I find the following error message:

```
40: Site needs HTTP authentication. Error: HTTP Error 412: Precondition Failed
```

I recalled the URL of our Zabbix server had changed, but I have not changed my code. The Zabbix API caught the exception,  so the script failed to catch it. 

If the Zabbix API can raise some exception, the caller can choose what to do with the exception.
