### PR TITLE
fixing SyntaxError in line 259, should be "elif" not a "elsif"

### DIFF
--- a/zabbix/zabbix_api.py
+++ b/zabbix/zabbix_api.py
@@ -256,7 +256,7 @@ class ZabbixAPI(object):
         except urllib2.URLError as e:
             if hasattr(e, 'message') and e.message:
                 e = e.message
-            elsif hasattr(e, 'reason'):
+            elif hasattr(e, 'reason'):
                 e = e.reason
             raise ZabbixAPIException("urllib2.URLError - %s" % e)
         self.debug(logging.INFO, "Response Code: " + str(response.code))


### PR DESCRIPTION
zabbix_api.py", line 259
   elsif hasattr(e, 'reason'):
               ^
SyntaxError: invalid syntax

should be a "elif" --->>> https://docs.python.org/2.7/tutorial/controlflow.html