### PR TITLE
Remove newlines from base64.encodestring output when using long basic auth

### DIFF
--- a/zabbix/zabbix_api.py
+++ b/zabbix/zabbix_api.py
@@ -225,7 +225,7 @@ class ZabbixAPI(object):
 
         if self.httpuser:
             self.debug(logging.INFO, "HTTP Auth enabled")
-            auth = 'Basic ' + string.strip(base64.encodestring(self.httpuser + ':' + self.httppasswd))
+            auth = 'Basic ' + string.strip(base64.encodestring(self.httpuser + ':' + self.httppasswd).replace('\n', '').replace('\r', ''))
             headers['Authorization'] = auth
         self.r_query.append(str(json_obj))
         self.debug(logging.INFO, "Sending: " + str(json_obj))

--- a/zabbix/zabbix_api.py
+++ b/zabbix/zabbix_api.py
@@ -225,7 +225,7 @@ class ZabbixAPI(object):
 
         if self.httpuser:
             self.debug(logging.INFO, "HTTP Auth enabled")
-            auth = 'Basic ' + string.strip(base64.encodestring(self.httpuser + ':' + self.httppasswd).replace('\n', '').replace('\r', ''))
+            auth = 'Basic ' + string.strip(base64.b64encode(self.httpuser + ':' + self.httppasswd))
             headers['Authorization'] = auth
         self.r_query.append(str(json_obj))
         self.debug(logging.INFO, "Sending: " + str(json_obj))


### PR DESCRIPTION
According to python documentation: 

> base64.encodestring(s)
> Encode the string s, which can contain arbitrary binary data, and return a string containing one or more lines of base64-encoded data. encodestring() returns a string containing one or more lines of base64-encoded data always including an extra trailing newline ('\n').

Having extra newline within the header will break the authentication process as the server will read only the first part of the encoded 'user:password'

