### PR TITLE
fix FIPS mode compatibility

### DIFF
--- a/zabbix/zabbix_api.py
+++ b/zabbix/zabbix_api.py
@@ -200,7 +200,7 @@ class ZabbixAPI(object):
             raise ZabbixAPIException("No authentication information available.")
 
         # don't print the raw password.
-        hashed_pw_string = "md5(" + hashlib.md5(l_password.encode('utf-8')).hexdigest() + ")"
+        hashed_pw_string = "md5(" + hashlib.md5(l_password.encode('utf-8'), usedforsecurity=False).hexdigest() + ")"
         self.debug(logging.DEBUG, "Trying to login with %s:%s" %
                 (repr(l_user), repr(hashed_pw_string)))
         obj = self.json_obj('user.login', {'user': l_user, 'password': l_password}, auth=False)


### PR DESCRIPTION
When using the `zabbix_api.py` script, in Ansible `zabbix_host` module, on a RHEL8 machine, with FIPS mode enabled, the following error is produced:
`Failed to connect to Zabbix server: [digital envelope routines: EVP_DigestInit_ex] disabled for FIPS`

The issue occurs on line 203, where the password is MD5 hashed before being printed to debug log:
```
        # don't print the raw password.
        hashed_pw_string = "md5(" + hashlib.md5(l_password.encode('utf-8'), usedforsecurity=False).hexdigest() + ")"
        self.debug(logging.DEBUG, "Trying to login with %s:%s" %
                (repr(l_user), repr(hashed_pw_string)))
```

Since the MD5 sum is only used for the debug log the simple options are to:
1. Indicate it's not used for security
2. Avoid printing the password to debug mode in any form

This PR accomplishes # 1 

Issue is similar to https://github.com/s3tools/s3cmd/issues/1005
