### PR TITLE
Resolve compatibility with python 2.7

### DIFF
--- a/zabbix/zabbix_api.py
+++ b/zabbix/zabbix_api.py
@@ -85,7 +85,7 @@ def version_compare(v1, v2):
     The result is 0 if v1 == v2, -1 if v1 < v2, and +1 if v1 > v2
     """
     for v1_part, v2_part in zip(v1.split("."), v2.split(".")):
-        if v1_part.isdecimal() and v2_part.isdecimal():
+        if unicode(v1_part).isdecimal() and unicode(v2_part).isdecimal():
             if int(v1_part) > int(v2_part):
                 return 1
             elif int(v1_part) < int(v2_part):


### PR DESCRIPTION
Resolves an error using the script to add monitoring with python 2:

    "msg": "Failed to connect to Zabbix server: 'str' object has no attribute 'isdecimal'"